### PR TITLE
Add transcription_options to AudioInfo

### DIFF
--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -40,6 +40,7 @@ class AudioInfo(NamedTuple):
     language: str
     language_probability: float
     duration: float
+    transcription_options: TranscriptionOptions
 
 
 class TranscriptionOptions(NamedTuple):
@@ -321,6 +322,7 @@ class WhisperModel:
             language=language,
             language_probability=language_probability,
             duration=duration,
+            transcription_options=options,
         )
 
         return segments, audio_info

--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -34,7 +34,7 @@ class Segment(NamedTuple):
     words: Optional[List[Word]]
     avg_log_prob: float
     no_speech_prob: float
-    
+
 
 class TranscriptionOptions(NamedTuple):
     beam_size: int

--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -34,14 +34,7 @@ class Segment(NamedTuple):
     words: Optional[List[Word]]
     avg_log_prob: float
     no_speech_prob: float
-
-
-class AudioInfo(NamedTuple):
-    language: str
-    language_probability: float
-    duration: float
-    transcription_options: TranscriptionOptions
-
+    
 
 class TranscriptionOptions(NamedTuple):
     beam_size: int
@@ -62,6 +55,13 @@ class TranscriptionOptions(NamedTuple):
     word_timestamps: bool
     prepend_punctuations: str
     append_punctuations: str
+
+
+class AudioInfo(NamedTuple):
+    language: str
+    language_probability: float
+    duration: float
+    transcription_options: TranscriptionOptions
 
 
 class WhisperModel:


### PR DESCRIPTION
It would be great if we can include the transcription_options in AudioInfo.

My application is only making a few changes but leaving the rest as default. However, I would like to record down all settings (including those that I did not specify) so that the audio can be transcribed again identically in future if need be.