### PR TITLE
Implementing #194

### DIFF
--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -17,6 +17,7 @@ from faster_whisper.vad import (
     SpeechTimestampsMap,
     collect_chunks,
     get_speech_timestamps,
+    VadOptions
 )
 
 
@@ -67,6 +68,7 @@ class TranscriptionInfo(NamedTuple):
     language_probability: float
     duration: float
     transcription_options: TranscriptionOptions
+    vad_options: VadOptions
 
 
 class WhisperModel:
@@ -177,7 +179,7 @@ class WhisperModel:
         prepend_punctuations: str = "\"'“¿([{-",
         append_punctuations: str = "\"'.。,，!！?？:：”)]}、",
         vad_filter: bool = False,
-        vad_parameters: Optional[dict] = None,
+        vad_parameters: Optional[dict | VadOptions] = VadOptions(),
     ) -> Tuple[Iterable[Segment], TranscriptionInfo]:
         """Transcribes an input file.
 
@@ -221,8 +223,8 @@ class WhisperModel:
           vad_filter: Enable the voice activity detection (VAD) to filter out parts of the audio
             without speech. This step is using the Silero VAD model
             https://github.com/snakers4/silero-vad.
-          vad_parameters: Dictionary of Silero VAD parameters (see available parameters and
-            default values in the function `get_speech_timestamps`).
+          vad_parameters: Dictionary of Silero VAD parameters or VadOptions class (see available parameters and
+            default values in the class `VadOptions`).
 
         Returns:
           A tuple with:
@@ -242,8 +244,9 @@ class WhisperModel:
         )
 
         if vad_filter:
-            vad_parameters = {} if vad_parameters is None else vad_parameters
-            speech_chunks = get_speech_timestamps(audio, **vad_parameters)
+            if isinstance(vad_parameters, dict):
+                vad_parameters = VadOptions.from_dict(vad_parameters)
+            speech_chunks = get_speech_timestamps(audio, vad_parameters)
             audio = collect_chunks(audio, speech_chunks)
 
             self.logger.info(
@@ -330,6 +333,7 @@ class WhisperModel:
             language_probability=language_probability,
             duration=duration,
             transcription_options=options,
+            vad_options=vad_parameters,
         )
 
         return segments, info

--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -179,7 +179,7 @@ class WhisperModel:
         prepend_punctuations: str = "\"'“¿([{-",
         append_punctuations: str = "\"'.。,，!！?？:：”)]}、",
         vad_filter: bool = False,
-        vad_parameters: Optional[dict | VadOptions] = VadOptions(),
+        vad_parameters: Optional[Union[dict, VadOptions]] = VadOptions(),
     ) -> Tuple[Iterable[Segment], TranscriptionInfo]:
         """Transcribes an input file.
 

--- a/faster_whisper/vad.py
+++ b/faster_whisper/vad.py
@@ -14,43 +14,50 @@ from faster_whisper.utils import get_assets_path
 class VadOptions(NamedTuple):
     threshold: float = 0.5
     """Speech threshold.
-    
-    Silero VAD outputs speech probabilities for each audio chunk, probabilities ABOVE this value are considered as 
-    SPEECH. It is better to tune this parameter for each dataset separately, but "lazy" 0.5 is pretty good for most 
-    datasets.
+
+    Silero VAD outputs speech probabilities for each audio chunk, probabilities ABOVE this value
+    are considered as SPEECH. It is better to tune this parameter for each dataset separately,
+    but "lazy" 0.5 is pretty good for most datasets.
     """
     min_speech_duration_ms: int = 250
-    """Final speech chunks shorter min_speech_duration_ms are thrown out."""
+    """Final speech chunks shorter min_speech_duration_ms are thrown out.
+    """
     max_speech_duration_s: float = float("inf"),
     """Maximum duration of speech chunks in seconds.
-    
-    Chunks longer than max_speech_duration_s will be split at the timestamp of the last silence that lasts more than 
-    100s (if any), to prevent agressive cutting. Otherwise, they will be split aggressively just before 
-    max_speech_duration_s.
+
+    Chunks longer than max_speech_duration_s will be split at the timestamp of the last silence
+    that lasts more than 100s (if any), to prevent agressive cutting. Otherwise, they will be
+    split aggressively just before max_speech_duration_s.
     """
     min_silence_duration_ms: int = 2000,
-    """In the end of each speech chunk wait for min_silence_duration_ms before separating it
+    """In the end of each speech chunk wait for min_silence_duration_ms before separating it.
     """
     window_size_samples: int = 1024,
     """Audio chunks of window_size_samples size are fed to the silero VAD model.
-    
+
     WARNING! Silero VAD models were trained using 512, 1024, 1536 samples for 16000 sample rate.
     Values other than these may affect model performance!!
     """
     speech_pad_ms: int = 400
-    """Final speech chunks are padded by speech_pad_ms each side"""
+    """Final speech chunks are padded by speech_pad_ms each side.
+    """
 
     @staticmethod
     def from_dict(values: dict) -> 'VadOptions':
         """Helper method to convert a dictionary of key-values into an VadOptions object
         """
-        result = VadOptions()
-        result.threshold = values.get("threshold", result.threshold)
-        result.min_speech_duration_ms = values.get("min_speech_duration_ms", result.min_speech_duration_ms)
-        result.max_speech_duration_s = values.get("max_speech_duration_s", result.max_speech_duration_s)
-        result.min_silence_duration_ms = values.get("min_silence_duration_ms", result.min_silence_duration_ms)
-        result.window_size_samples = values.get("window_size_samples", result.window_size_samples)
-        result.speech_pad_ms = values.get("speech_pad_ms", result.speech_pad_ms)
+        result = VadOptions(
+            threshold=values.get("threshold", VadOptions().threshold),
+            min_speech_duration_ms=values.get("min_speech_duration_ms",
+                                              VadOptions().min_speech_duration_ms),
+            max_speech_duration_s=values.get("max_speech_duration_s",
+                                             VadOptions().max_speech_duration_s),
+            min_silence_duration_ms=values.get("min_silence_duration_ms",
+                                               VadOptions().min_silence_duration_ms),
+            window_size_samples=values.get("window_size_samples",
+                                           VadOptions().window_size_samples),
+            speech_pad_ms=values.get("speech_pad_ms", VadOptions().speech_pad_ms),
+        )
         return result
 
 


### PR DESCRIPTION
1. I've created a new `VadOptions` class in vad.py to hold the list of options and default values.
2. I've also changed the parameters of `get_speech_timestamps` to use the VadOptions class.
I know that #194 said that perhaps we should leave the parameters as-is, but it really looks strange to have the `VadOptions` class defined at the top with defaults, and the `get_speech_timestamps` to not have any defaults.
3. `TranscriptionInfo` now also contains `VadOptions`.
4. Edited the `transcribe` and `get_speech_timestamps` documentation to mention the `VadOptions` class.