### PR TITLE
transcribe: return all language probabilities if requested

### DIFF
--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -190,7 +190,7 @@ class WhisperModel:
           language: The language spoken in the audio. It should be a language code such
             as "en" or "fr". If not set, the language will be detected in the first 30 seconds
             of audio.
-          return_all_language_probs: If `True`, `TranscriptInfo` will return all language
+          return_all_language_probs: If `True`, `TranscriptionInfo` will return all language
             probabilities in addition to the top one.
           task: Task to execute (transcribe or translate).
           beam_size: Beam size to use for decoding.

--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -153,7 +153,6 @@ class WhisperModel:
         self,
         audio: Union[str, BinaryIO, np.ndarray],
         language: Optional[str] = None,
-        return_all_language_probs: bool = False,
         task: str = "transcribe",
         beam_size: int = 5,
         best_of: int = 5,
@@ -190,8 +189,6 @@ class WhisperModel:
           language: The language spoken in the audio. It should be a language code such
             as "en" or "fr". If not set, the language will be detected in the first 30 seconds
             of audio.
-          return_all_language_probs: If `True`, `TranscriptionInfo` will return all language
-            probabilities in addition to the top one.
           task: Task to execute (transcribe or translate).
           beam_size: Beam size to use for decoding.
           best_of: Number of candidates when sampling with non-zero temperature.
@@ -345,9 +342,7 @@ class WhisperModel:
             duration=duration,
             transcription_options=options,
             vad_options=vad_parameters,
-            all_language_probs=all_language_probs
-            if return_all_language_probs
-            else None,
+            all_language_probs=all_language_probs,
         )
 
         return segments, info

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -6,10 +6,24 @@ from faster_whisper import WhisperModel, decode_audio
 def test_transcribe(jfk_path):
     model = WhisperModel("tiny")
     segments, info = model.transcribe(jfk_path, word_timestamps=True)
+    assert info.all_language_probs is None
+
+    # Compare all language probs against the top one
+    _, info_with_probs = model.transcribe(
+        jfk_path, return_all_language_probs=True, word_timestamps=True
+    )
+    # Should not be None now
+    assert info_with_probs.all_language_probs is not None
 
     assert info.language == "en"
     assert info.language_probability > 0.9
     assert info.duration == 11
+
+    # Get top language info from all results, which should match the
+    # already existing metadata
+    top_lang, top_lang_score = info_with_probs.all_language_probs[0]
+    assert info.language == top_lang
+    assert abs(info.language_probability - top_lang_score) < 1e-16
 
     segments = list(segments)
 

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -6,14 +6,7 @@ from faster_whisper import WhisperModel, decode_audio
 def test_transcribe(jfk_path):
     model = WhisperModel("tiny")
     segments, info = model.transcribe(jfk_path, word_timestamps=True)
-    assert info.all_language_probs is None
-
-    # Compare all language probs against the top one
-    _, info_with_probs = model.transcribe(
-        jfk_path, return_all_language_probs=True, word_timestamps=True
-    )
-    # Should not be None now
-    assert info_with_probs.all_language_probs is not None
+    assert info.all_language_probs is not None
 
     assert info.language == "en"
     assert info.language_probability > 0.9
@@ -21,7 +14,7 @@ def test_transcribe(jfk_path):
 
     # Get top language info from all results, which should match the
     # already existing metadata
-    top_lang, top_lang_score = info_with_probs.all_language_probs[0]
+    top_lang, top_lang_score = info.all_language_probs[0]
     assert info.language == top_lang
     assert abs(info.language_probability - top_lang_score) < 1e-16
 


### PR DESCRIPTION
This change adds a `all_language_probs` field to `TranscriptionInfo` so that when language detection is done, we can recover the full probabilities from the model in addition to the top one.