### PR TITLE
Enable onnxruntime dependency for Python 3.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ av==10.*
 ctranslate2>=3.10,<4
 huggingface_hub>=0.13
 tokenizers==0.13.*
-onnxruntime==1.14.* ; python_version < "3.11"
+onnxruntime>=1.14,<2


### PR DESCRIPTION
onnxruntime 1.15.0 was just released with Python 3.11 support.