### PR TITLE
Do not specify the vocabulary file extension in the download pattern

### DIFF
--- a/faster_whisper/utils.py
+++ b/faster_whisper/utils.py
@@ -68,7 +68,7 @@ def download_model(
         "config.json",
         "model.bin",
         "tokenizer.json",
-        "vocabulary.txt",
+        "vocabulary.*",
     ]
 
     kwargs = {


### PR DESCRIPTION
Models converted with CTranslate2 3.16 and above now save the vocabulary as `vocabulary.json`.

For now there is no plan to update the converted models in the Hugging Face Hub which still use vocabularies as text files. But we make this change now in case they get updated in the future.