### PR TITLE
Add support for using whisper models from Huggingface by specifying the model id.

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,14 +161,14 @@ ct2-transformers-converter --model openai/whisper-large-v2 --output_dir whisper-
 
 Models can also be converted from the code. See the [conversion API](https://opennmt.net/CTranslate2/python/ctranslate2.converters.TransformersConverter.html).
 
-### Use converted model
+### Load a converted model
 
-1. Directly use model from local directory:
+1. Directly load the model from a local directory:
 ```python
 model = faster_whisper.WhisperModel('whisper-large-v2-ct2')
 ```
 
-2. [Upload your model to Huggingface](https://huggingface.co/docs/transformers/model_sharing#upload-with-the-web-interface) and use online:
+2. [Upload your model to the Hugging Face Hub](https://huggingface.co/docs/transformers/model_sharing#upload-with-the-web-interface) and load it from its name:
 ```python
 model = faster_whisper.WhisperModel('username/whisper-large-v2-ct2')
 ```

--- a/README.md
+++ b/README.md
@@ -72,8 +72,6 @@ model = WhisperModel(model_size, device="cuda", compute_type="float16")
 # model = WhisperModel(model_size, device="cuda", compute_type="int8_float16")
 # or run on CPU with INT8
 # model = WhisperModel(model_size, device="cpu", compute_type="int8")
-# or use available models (https://huggingface.co/models?search=faster-whisper) from Huggingface
-# model = WhisperModel('zh-plus/faster-whisper-large-v2-japanese-5k-steps')
 
 segments, info = model.transcribe("audio.mp3", beam_size=5)
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ model = WhisperModel(model_size, device="cuda", compute_type="float16")
 # model = WhisperModel(model_size, device="cuda", compute_type="int8_float16")
 # or run on CPU with INT8
 # model = WhisperModel(model_size, device="cpu", compute_type="int8")
+# or use available models (https://huggingface.co/models?search=faster-whisper) from Huggingface
+# model = WhisperModel('zh-plus/faster-whisper-large-v2-japanese-5k-steps')
 
 segments, info = model.transcribe("audio.mp3", beam_size=5)
 
@@ -160,6 +162,18 @@ ct2-transformers-converter --model openai/whisper-large-v2 --output_dir whisper-
 * If the option `--copy_files tokenizer.json` is not used, the tokenizer configuration is automatically downloaded when the model is loaded later.
 
 Models can also be converted from the code. See the [conversion API](https://opennmt.net/CTranslate2/python/ctranslate2.converters.TransformersConverter.html).
+
+### Use converted model
+
+1. Directly use model from local directory:
+```python
+model = faster_whisper.WhisperModel('whisper-large-v2-ct2')
+```
+
+2. [Upload your model to Huggingface](https://huggingface.co/docs/transformers/model_sharing#upload-with-the-web-interface) and use online:
+```python
+model = faster_whisper.WhisperModel('username/whisper-large-v2-ct2')
+```
 
 ## Comparing performance against other implementations
 

--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -88,8 +88,9 @@ class WhisperModel:
 
         Args:
           model_size_or_path: Size of the model to use (tiny, tiny.en, base, base.en,
-            small, small.en, medium, medium.en, large-v1, or large-v2) or a path to a converted
-            model directory. When a size is configured, the converted model is downloaded
+            small, small.en, medium, medium.en, large-v1, or large-v2), a path to a converted
+            model directory, or a CTranslate-converted whisper model ID from Huggingface.
+            When a size or a model ID is configured, the converted model is downloaded
             from the Hugging Face Hub.
           device: Device to use for computation ("cpu", "cuda", "auto").
           device_index: Device ID to use.

--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -89,7 +89,7 @@ class WhisperModel:
         Args:
           model_size_or_path: Size of the model to use (tiny, tiny.en, base, base.en,
             small, small.en, medium, medium.en, large-v1, or large-v2), a path to a converted
-            model directory, or a CTranslate-converted whisper model ID from Huggingface.
+            model directory, or a CTranslate2-converted Whisper model ID from the Hugging Face Hub.
             When a size or a model ID is configured, the converted model is downloaded
             from the Hugging Face Hub.
           device: Device to use for computation ("cpu", "cuda", "auto").

--- a/faster_whisper/utils.py
+++ b/faster_whisper/utils.py
@@ -59,12 +59,13 @@ def download_model(
     Raises:
       ValueError: if the model size is invalid.
     """
-    if re.match(r'.*/.*', size_or_id):
+    if re.match(r".*/.*", size_or_id):
         repo_id = size_or_id
     else:
         if size_or_id not in _MODELS:
             raise ValueError(
-                "Invalid model size '%s', expected one of: %s" % (size_or_id, ", ".join(_MODELS))
+                "Invalid model size '%s', expected one of: %s"
+                % (size_or_id, ", ".join(_MODELS))
             )
 
         repo_id = "guillaumekln/faster-whisper-%s" % size_or_id

--- a/faster_whisper/utils.py
+++ b/faster_whisper/utils.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 
 from typing import Optional
 
@@ -33,7 +34,7 @@ def get_logger():
 
 
 def download_model(
-    size: str,
+    size_or_id: str,
     output_dir: Optional[str] = None,
     local_files_only: bool = False,
     cache_dir: Optional[str] = None,
@@ -43,8 +44,9 @@ def download_model(
     The model is downloaded from https://huggingface.co/guillaumekln.
 
     Args:
-      size: Size of the model to download (tiny, tiny.en, base, base.en, small, small.en,
-        medium, medium.en, large-v1, or large-v2).
+      size_or_id: Size of the model to download (tiny, tiny.en, base, base.en, small, small.en,
+        medium, medium.en, large-v1, or large-v2),
+        or CTranslate-converted model id from Huggingface (e.g. guillaumekln/faster-whisper-large-v2).
       output_dir: Directory where the model should be saved. If not set, the model is saved in
         the cache directory.
       local_files_only:  If True, avoid downloading the file and return the path to the local
@@ -57,12 +59,15 @@ def download_model(
     Raises:
       ValueError: if the model size is invalid.
     """
-    if size not in _MODELS:
-        raise ValueError(
-            "Invalid model size '%s', expected one of: %s" % (size, ", ".join(_MODELS))
-        )
+    if re.match(r'.*/.*', size_or_id):
+        repo_id = size_or_id
+    else:
+        if size_or_id not in _MODELS:
+            raise ValueError(
+                "Invalid model size '%s', expected one of: %s" % (size_or_id, ", ".join(_MODELS))
+            )
 
-    repo_id = "guillaumekln/faster-whisper-%s" % size
+        repo_id = "guillaumekln/faster-whisper-%s" % size_or_id
 
     allow_patterns = [
         "config.json",

--- a/faster_whisper/utils.py
+++ b/faster_whisper/utils.py
@@ -45,8 +45,8 @@ def download_model(
 
     Args:
       size_or_id: Size of the model to download (tiny, tiny.en, base, base.en, small, small.en,
-        medium, medium.en, large-v1, or large-v2), or CTranslate-converted model ID
-        from Huggingface (e.g. guillaumekln/faster-whisper-large-v2).
+        medium, medium.en, large-v1, or large-v2), or a CTranslate2-converted model ID
+        from the Hugging Face Hub (e.g. guillaumekln/faster-whisper-large-v2).
       output_dir: Directory where the model should be saved. If not set, the model is saved in
         the cache directory.
       local_files_only:  If True, avoid downloading the file and return the path to the local

--- a/faster_whisper/utils.py
+++ b/faster_whisper/utils.py
@@ -45,8 +45,8 @@ def download_model(
 
     Args:
       size_or_id: Size of the model to download (tiny, tiny.en, base, base.en, small, small.en,
-        medium, medium.en, large-v1, or large-v2),
-        or CTranslate-converted model id from Huggingface (e.g. guillaumekln/faster-whisper-large-v2).
+        medium, medium.en, large-v1, or large-v2), or CTranslate-converted model ID
+        from Huggingface (e.g. guillaumekln/faster-whisper-large-v2).
       output_dir: Directory where the model should be saved. If not set, the model is saved in
         the cache directory.
       local_files_only:  If True, avoid downloading the file and return the path to the local


### PR DESCRIPTION
Recently, I successfully converted a fine-tuned Whisper model using CTranslate and utilized it by calling the following code:

```
model = faster_whisper.WhisperModel('converted-whisper-model')
```
, which works well.

However, when I attempted to push this converted model into Hub, I encountered an issue where the `WhisperModel` was unable to directly download the converted model from Hub. To resolve this problem, I made slight modifications to the `download_model` function in order for it to work properly.

