### PR TITLE
Invalidate the cached encoder output when no_speech threshold is met

### DIFF
--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -422,6 +422,7 @@ class WhisperModel:
 
                     # fast-forward to the next segment boundary
                     seek += segment_size
+                    encoder_output = None
                     continue
 
             tokens = result.sequences_ids[0]


### PR DESCRIPTION
Without this line, the next 30-second window will use the same encoder output as the previous one which is incorrect. 