### PR TITLE
fix subtitle start time advance or end time delay, when set vad_filter to True

### DIFF
--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -900,10 +900,9 @@ def restore_speech_timestamps(
             )
 
         else:
-            segment = segment._replace(
-                start=ts_map.get_original_time(segment.start),
-                end=ts_map.get_original_time(segment.end),
-            )
+            seg_start, seg_end = ts_map.get_original_segment_time(
+                segment.start, segment.end)
+            segment = segment._replace(start=seg_start, end=seg_end)
 
         yield segment
 

--- a/faster_whisper/vad.py
+++ b/faster_whisper/vad.py
@@ -233,6 +233,33 @@ class SpeechTimestampsMap:
             len(self.chunk_end_sample) - 1,
         )
 
+    def get_original_segment_time(
+        self,
+        start_time: float,
+        end_time: float,
+    ) -> float:
+        start_chunk_index = self.get_chunk_index(start_time)
+        end_chunk_index = self.get_chunk_index(end_time)
+        if start_chunk_index != end_chunk_index:
+            span_chunk_sample = self.chunk_end_sample[start_chunk_index]
+            start_sample = int(start_time * self.sampling_rate)
+            end_sample = int(end_time * self.sampling_rate)
+            if ((span_chunk_sample - start_sample)
+                > (end_sample - span_chunk_sample)
+            ):
+                end_chunk_index = start_chunk_index
+            else:
+                start_chunk_index = end_chunk_index
+        original_start_time = self.get_original_time(
+            start_time,
+            chunk_index=start_chunk_index,
+        )
+        original_end_time = self.get_original_time(
+            end_time,
+            chunk_index=end_chunk_index,
+        )
+        return (original_start_time, original_end_time)
+
 
 @functools.lru_cache
 def get_vad_model():


### PR DESCRIPTION
Use faster-whisper to generate subtitles, set vad_filter to true. In the subtitle results, it is found that the start time of many subtitles is much earlier than the actual voice, or the end time of the subtitles is too long. After debugging, I found that after vad_filter is set to true, the segments produced by the model need to restore the start time and end time of each subtitle; but I found a problem here, when the start time and end time of a segment It spans two chunks (chunk is when vad_filter is true, the original audio is divided into different chunks through non-speech detection), in this case, the start time of the segment will be wrongly advanced for a period of time or the end time will be wrong Delay for a period of time (this period is the duration of the non-speech segment between two chunks).
In order to fix this problem, I rewrote a method to fix the segment start time and end time. If the start time and end time are in different chunks, a simple logic will be used to determine which chunk the segment should actually belong to, and then match it time to correct.
Through the modification of the above code, I solved most of the subtitle time misalignment problems I encountered here.