### PR TITLE
Token repeat limit, hallucination helper option.

### DIFF
--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -247,7 +247,7 @@ class WhisperModel:
             without speech. This step is using the Silero VAD model
             https://github.com/snakers4/silero-vad.
           vad_parameters: Dictionary of Silero VAD parameters or VadOptions class (see available
-            parameters and default values in the class `VadOptions`).
+          token_repeat_limit: Predictions with token repeats (consecutive) over this, are failed
 
         Returns:
           A tuple with:

--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -20,6 +20,7 @@ from faster_whisper.vad import (
     get_speech_timestamps,
 )
 
+
 def consecutive_repeat_sizes(arr):
     result = {}
     current_num = None
@@ -38,6 +39,7 @@ def consecutive_repeat_sizes(arr):
         result[current_num] = max(result.get(current_num, 0), current_count)
 
     return result
+
 
 class Word(NamedTuple):
     start: float
@@ -659,7 +661,10 @@ class WhisperModel:
                 counts = consecutive_repeat_sizes(tokens)
                 for k, v in counts.items():
                     if v > options.token_repeat_limit:
-                        self.logger.debug(f"Fallback. Many token repeats, likely hallucination ({v} > {options.token_repeat_limit})")
+                        self.logger.debug(
+                            "Fallback. Many token repeats, likely hallucination"
+                            f"({v} > {options.token_repeat_limit})"
+                        )
                         needs_fallback = True
 
             if options.compression_ratio_threshold is not None:


### PR DESCRIPTION
Implemented an argument option to transcribe `token_repeat_limit `.
Predictions with token repeats (consecutive) over this, are failed (with fallback, like other thresholds)
Implemented with filtering of simple extreme repetition (100+ tokens) in mind.

By default this option is disabled of course, and doesn't go inside the `if` branch added.

Predictions with token repeats such as this one are failed (has 222 consecutive token repeats, obviously a hallucination):

```python
[Segment(id=1, seek=200, start=0.0, end=2.0, text=' Suggestions!', tokens=[50364, 39131, 2629, 626, 0, 50464], temperature=0.4, avg_logprob=-0.07976385182804531, compression_ratio=16.59259259259259, no_speech_prob=0.30723854899406433, words=None), Segment(id=2, seek=1395, start=2.0, end=13.950000000000001, text=' Hmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm', tokens=[50364, 8239, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174, 2174], temperature=0.2, avg_logprob=-0.056518122487597994, compression_ratio=31.928571428571427, no_speech_prob=0.6861338019371033, words=None)]
```

The correct caption for this audio is:
```
 Do you have any suggestions?
 Hmmm...
 I don't know...
 Like, like...
```
The "Hmmmm..." prediction goes so long for the prediction with many repeats that it eats up the following other dialogue for some reason (segment from 2.0s to 13.9s, when the Hmmm... actually takes around 1.82 seconds).

I've seen similar repeats happen multiple times in my experience with different audio tracks, but if you want the sample I can share.

Kind of specific, but also very simple addition.

A token_repeat_size could be implemented for cases where tokens are repeated like [x,y, x,y, x,y, ... ], instead of just [x,x,x...]