### PR TITLE
Add a threshold_limit_ratio parameter

### DIFF
--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -50,6 +50,7 @@ class TranscriptionOptions(NamedTuple):
     log_prob_threshold: Optional[float]
     no_speech_threshold: Optional[float]
     compression_ratio_threshold: Optional[float]
+    threshold_limit_ratio: Optional[float]
     condition_on_previous_text: bool
     temperatures: List[float]
     initial_prompt: Optional[Union[str, Iterable[int]]]
@@ -170,6 +171,7 @@ class WhisperModel:
         compression_ratio_threshold: Optional[float] = 2.4,
         log_prob_threshold: Optional[float] = -1.0,
         no_speech_threshold: Optional[float] = 0.6,
+        threshold_limit_ratio: Optional[float] = None,
         condition_on_previous_text: bool = True,
         initial_prompt: Optional[Union[str, Iterable[int]]] = None,
         prefix: Optional[str] = None,
@@ -318,6 +320,7 @@ class WhisperModel:
             log_prob_threshold=log_prob_threshold,
             no_speech_threshold=no_speech_threshold,
             compression_ratio_threshold=compression_ratio_threshold,
+            threshold_limit_ratio=threshold_limit_ratio,
             condition_on_previous_text=condition_on_previous_text,
             temperatures=(
                 temperature if isinstance(temperature, (list, tuple)) else [temperature]

--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -532,6 +532,40 @@ class WhisperModel:
                     if seek_shift > 0:
                         seek = previous_seek + seek_shift
 
+            # low avg_logprob check
+            if (
+                options.log_prob_threshold is not None
+                and options.threshold_limit_ratio is not None
+                and avg_logprob
+                < options.log_prob_threshold * options.threshold_limit_ratio
+            ):
+                self.logger.debug(
+                    "Average log probability is too low (%f < %f * %f)",
+                    avg_logprob,
+                    options.log_prob_threshold,
+                    options.threshold_limit_ratio,
+                )
+
+                encoder_output = None
+                continue
+
+            # high compression ratio check
+            if (
+                options.compression_ratio_threshold is not None
+                and options.log_prob_threshold is not None
+                and compression_ratio
+                > options.compression_ratio_threshold * options.threshold_limit_ratio
+            ):
+                self.logger.debug(
+                    "Compression ratio is too high (%f > %f * %f)",
+                    compression_ratio,
+                    options.compression_ratio_threshold,
+                    options.threshold_limit_ratio,
+                )
+
+                encoder_output = None
+                continue
+
             encoder_output = None
 
             for segment in current_segments:

--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -552,7 +552,7 @@ class WhisperModel:
             # high compression ratio check
             if (
                 options.compression_ratio_threshold is not None
-                and options.log_prob_threshold is not None
+                and options.threshold_limit_ratio is not None
                 and compression_ratio
                 > options.compression_ratio_threshold * options.threshold_limit_ratio
             ):


### PR DESCRIPTION
We can already set the `avg_logprob_threshold` and `compression_ratio_threshold` to trigger the fallback.

However, we still had to rely on the user to filter out segments with very low `avg_logprob` or very high `compression_ratio` values.

Segments with a very low `avg_logprob` or a very high `compression ratio` are very likely to be mis-transcribed or hallucinations, and thus may adversely affect subsequent transcription due to the `condition_on_previous_text` option.

This PR prevents these sentences from being output, and also from being added to the previous token. 
This will be useful for users who want to get better accuracy in exchange for a few missing sentences.

In my use case, a value of `threshold_limit_ratio = 2` worked well when `log_prob_threshold` and `compression_ratio_threshold` were at their defaults, and I was able to reduce the hallucinations considerably. 
However, given the variety of use cases, I would recommend leaving the defaults at `None` and letting users adjust them themselves.

For `no_speech_prob`, I didn't consider this value because it's often inaccurate.