### PR TITLE
added repetition_penalty to TranscriptionOptions

### DIFF
--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -47,6 +47,7 @@ class TranscriptionOptions(NamedTuple):
     best_of: int
     patience: float
     length_penalty: float
+    repetition_penalty: float
     log_prob_threshold: Optional[float]
     no_speech_threshold: Optional[float]
     compression_ratio_threshold: Optional[float]
@@ -159,6 +160,7 @@ class WhisperModel:
         best_of: int = 5,
         patience: float = 1,
         length_penalty: float = 1,
+        repetition_penalty: float = 1,
         temperature: Union[float, List[float], Tuple[float, ...]] = [
             0.0,
             0.2,
@@ -195,6 +197,8 @@ class WhisperModel:
           best_of: Number of candidates when sampling with non-zero temperature.
           patience: Beam search patience factor.
           length_penalty: Exponential length penalty constant.
+          repetition_penalty: Penalty applied to the score of previously generated tokens
+            (set > 1 to penalize).
           temperature: Temperature for sampling. It can be a tuple of temperatures,
             which will be successively used upon failures according to either
             `compression_ratio_threshold` or `log_prob_threshold`.
@@ -315,6 +319,7 @@ class WhisperModel:
             best_of=best_of,
             patience=patience,
             length_penalty=length_penalty,
+            repetition_penalty=repetition_penalty,
             log_prob_threshold=log_prob_threshold,
             no_speech_threshold=no_speech_threshold,
             compression_ratio_threshold=compression_ratio_threshold,
@@ -605,6 +610,7 @@ class WhisperModel:
                 encoder_output,
                 [prompt],
                 length_penalty=options.length_penalty,
+                repetition_penalty=options.repetition_penalty,
                 max_length=self.max_length,
                 return_scores=True,
                 return_no_speech_prob=True,


### PR DESCRIPTION
CTranslate2 has a `repetition_penalty` argument in its model.generate method. It was however missing from WhisperModel.transcribe

Simply added the `repetition_penalty` argument

As it is, after each generation, the output is filtered if it's too repetitive (based on compression_ratio).
`repetition_penalty` can make it so repetition is penalized during the generation (decoding) itself, making some failure cases like I found disappear.

By "failure" in this case I mean taking 23 seconds to process a 13 second clip (which usually takes ~2.4 seconds) because of obvious repetition in multiple fallbacks, as seen in this image  https://files.catbox.moe/d0psud.png, where each line starting with `needs_fallback` shows the result of a `model.generation`.

`repetition_penalty` solves this hallucination problem I was having #394 almost perfectly, (using `repetition_penalty=1.2`).

Just by using `repetition_penalty=1.2` it gets a non-hallucinated reply on the first try, though lower values already help on avoiding the worst cases like above. (Maybe setting `repetition_penalty` above one (always) is undesirable, I could see an implementation where a big hallucination is detected (the first generation has `compression_ratio=10` after all!) and increasing the repetition penalty on the second generation.)