### PR TITLE
Added audio duration after VAD to TranscriptionInfo object

### DIFF
--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -69,6 +69,7 @@ class TranscriptionInfo(NamedTuple):
     language: str
     language_probability: float
     duration: float
+    silence: float
     all_language_probs: Optional[List[Tuple[str, float]]]
     transcription_options: TranscriptionOptions
     vad_options: VadOptions
@@ -249,6 +250,7 @@ class WhisperModel:
             audio = decode_audio(audio, sampling_rate=sampling_rate)
 
         duration = audio.shape[0] / sampling_rate
+        silence = None
 
         self.logger.info(
             "Processing audio with duration %s", format_timestamp(duration)
@@ -261,6 +263,7 @@ class WhisperModel:
                 vad_parameters = VadOptions(**vad_parameters)
             speech_chunks = get_speech_timestamps(audio, vad_parameters)
             audio = collect_chunks(audio, speech_chunks)
+            silence = duration - (audio.shape[0] / sampling_rate)
 
             self.logger.info(
                 "VAD filter removed %s of audio",
@@ -352,6 +355,7 @@ class WhisperModel:
             language=language,
             language_probability=language_probability,
             duration=duration,
+            silence=silence,
             transcription_options=options,
             vad_options=vad_parameters,
             all_language_probs=all_language_probs,

--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -69,7 +69,7 @@ class TranscriptionInfo(NamedTuple):
     language: str
     language_probability: float
     duration: float
-    silence: float
+    duration_after_vad: float
     all_language_probs: Optional[List[Tuple[str, float]]]
     transcription_options: TranscriptionOptions
     vad_options: VadOptions
@@ -250,7 +250,7 @@ class WhisperModel:
             audio = decode_audio(audio, sampling_rate=sampling_rate)
 
         duration = audio.shape[0] / sampling_rate
-        silence = None
+        duration_after_vad = duration
 
         self.logger.info(
             "Processing audio with duration %s", format_timestamp(duration)
@@ -263,11 +263,11 @@ class WhisperModel:
                 vad_parameters = VadOptions(**vad_parameters)
             speech_chunks = get_speech_timestamps(audio, vad_parameters)
             audio = collect_chunks(audio, speech_chunks)
-            silence = duration - (audio.shape[0] / sampling_rate)
+            duration_after_vad = audio.shape[0] / sampling_rate
 
             self.logger.info(
                 "VAD filter removed %s of audio",
-                format_timestamp(duration - (audio.shape[0] / sampling_rate)),
+                format_timestamp(duration - duration_after_vad),
             )
 
             if self.logger.isEnabledFor(logging.DEBUG):
@@ -355,7 +355,7 @@ class WhisperModel:
             language=language,
             language_probability=language_probability,
             duration=duration,
-            silence=silence,
+            duration_after_vad=duration_after_vad,
             transcription_options=options,
             vad_options=vad_parameters,
             all_language_probs=all_language_probs,


### PR DESCRIPTION
Simple change that adds the seconds of audio removed by the VAD to the returned info object. This was added next to the duration of the original audio. Silero VAD refers to that as silence so that is the name I used.