### PR TITLE
added content_frames field

### DIFF
--- a/faster_whisper/transcribe.py
+++ b/faster_whisper/transcribe.py
@@ -31,6 +31,7 @@ class Word(NamedTuple):
 class Segment(NamedTuple):
     id: int
     seek: int
+    content_frames: int
     start: float
     end: float
     text: str
@@ -569,6 +570,7 @@ class WhisperModel:
                 yield Segment(
                     id=idx,
                     seek=seek,
+                    content_frames=content_frames,
                     start=segment["start"],
                     end=segment["end"],
                     text=text,


### PR DESCRIPTION
Hi, I really appreciate for implementing so much efficient whisper. 
This PR adds `content_frames` to `Segment`, so user can track the progress of the generator without exhausting it.
I personally wish there were `content_frames` for the `Segment`.

This is useful when you need to track progress in other frameworks like `gradio`. 

For example, you can do it like this:
```
import gradio as gr 

def transcribe(**params, progress= gr.Progress()):
    generator, info = faster_whisper_model.transcribe(**params)
    for segment in generator:
        progress(segment.seek / segment.content_frames, desc="Transcribing..")
```