### PR TITLE
Add support for whisper-large-v3

### DIFF
--- a/faster_whisper/utils.py
+++ b/faster_whisper/utils.py
@@ -20,6 +20,7 @@ _MODELS = {
     "medium": "guillaumekln/faster-whisper-medium",
     "large-v1": "guillaumekln/faster-whisper-large-v1",
     "large-v2": "guillaumekln/faster-whisper-large-v2",
+    "large-v3": "dougtrajano/faster-whisper-large-v3",
     "large": "guillaumekln/faster-whisper-large-v2",
 }
 


### PR DESCRIPTION
In this PR, we are introducing the support for [openai/whisper-large-v3](https://huggingface.co/openai/whisper-large-v3).

I followed the Conversion Details you added in [guillaumekln/faster-whisper-large-v2](https://huggingface.co/guillaumekln/faster-whisper-large-v2) to convert the new version and publish it to Hugging Face, which is available in [dougtrajano/faster-whisper-large-v3 · Hugging Face](https://huggingface.co/dougtrajano/faster-whisper-large-v3).

Related issues: #547, #544